### PR TITLE
Hit SIGSEGV because of the increased Difficulty.

### DIFF
--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -176,14 +176,14 @@ std::string dev::getScaledSize(double _value, double _divisor, int _precision, s
 
 std::string dev::getFormattedHashes(double _hr, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"h", "Kh", "Mh", "Gh"};
-    return dev::getScaledSize(_hr, 1000.0, _precision, suffixes, 4, _suffix);
+    static string suffixes[] = {"h", "Kh", "Mh", "Gh", "Th", "Ph"};
+    return dev::getScaledSize(_hr, 1000.0, _precision, suffixes, 6, _suffix);
 }
 
 std::string dev::getFormattedMemory(double _mem, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"B", "KB", "MB", "GB"};
-    return dev::getScaledSize(_mem, 1024.0, _precision, suffixes, 4, _suffix);
+    static string suffixes[] = {"B", "KB", "MB", "GB", "TB", "PB"};
+    return dev::getScaledSize(_mem, 1024.0, _precision, suffixes, 6, _suffix);
 }
 
 std::string dev::padLeft(std::string _value, size_t _length, char _fillChar) 


### PR DESCRIPTION
The issue is reproed in Linux environment only for now.

How to repro:

Run ethminer  --cuda --pool http://localhost:8080

On Windows, it does not crash, but prints random string for the unit of hash while it prints difficulty.

On CentOS with gcc-9, it crashes with SIGSEGV.

Root cause:
dev::getFormattedHashes has only up to Gh, not Th.

Fix:
Add Th, Ph to dev::getFormattedHashes.
Also add TB, PB to dev::getFormattedMemory to eliminate future problems.